### PR TITLE
Filter out draft blog posts

### DIFF
--- a/src/_includes/base.11ty.js
+++ b/src/_includes/base.11ty.js
@@ -251,6 +251,7 @@ function posts(data, { tag = "blog", limit } = {}) {
       ${pages
         .reverse()
         .slice(0, limit)
+        .filter((page) => !page.data.draft)
         .map(
           ({ url, data }) => html`
             <li ${!limit && `class="list-separator"`}>

--- a/src/blog/test-blog-piece.md
+++ b/src/blog/test-blog-piece.md
@@ -1,20 +1,24 @@
 ---
 title: Test blog post
 date: 2015-07-01
+draft: true
 tags:
   - chocolate
   - cake
   - icecream
 ---
+
 {% callout %}
+
 This is an intro!!! ck before Graphical User Interfaces (or GUIs) were invented ack before Graphical User Interfaces (or GUIs) were invented ack before Graphical User Interfaces (or GUIs) were invented a
+
 {% endcallout %}
 
 ## H2
 
 ck before Graphical User Interfaces (or GUIs) were invented a [terminal](https://en.wikipedia.org/wiki/Computer_terminal) was a separate piece of hardware that let an operator interact with a computer that probably filled an entire separate room. rthvtrb
 
-Full width image: 
+Full width image:
 
 {% layout "full" %}
 
@@ -24,7 +28,7 @@ Full width image:
 
 ### H3
 
-Way back before Graphical {% layout "right" %}![](https://cdn-images-1.medium.com/max/2000/1*kHgrc8FpN1G04kH37_dnLw.jpeg){% endlayout %}invented a [terminal](https://en.wikipedia.org/wiki/Computer_terminal)User Interfaces  (or GUIs) were  was a separate piece of hardware that let an operator interact with a computer that probably filled an entire separate room. Way back before Graphical User Interfaces (or GUIs) were invented a [terminal](https://en.wikipedia.org/wiki/Computer_terminal) was a separate piece of hardware that let an operator interact with a computer that probably filled an entire separate room.
+Way back before Graphical {% layout "right" %}![](https://cdn-images-1.medium.com/max/2000/1*kHgrc8FpN1G04kH37_dnLw.jpeg){% endlayout %}invented a [terminal](https://en.wikipedia.org/wiki/Computer_terminal)User Interfaces (or GUIs) were was a separate piece of hardware that let an operator interact with a computer that probably filled an entire separate room. Way back before Graphical User Interfaces (or GUIs) were invented a [terminal](https://en.wikipedia.org/wiki/Computer_terminal) was a separate piece of hardware that let an operator interact with a computer that probably filled an entire separate room.
 dfgnf 🏃‍♂️
 
 #### H4


### PR DESCRIPTION
Any post with `draft: true` in the data will still be published (so you can visit the URL directly) but won't show up in the list of posts on the home/blog pages.

<img width="1680" alt="Screenshot 2021-04-07 at 11 36 11" src="https://user-images.githubusercontent.com/9408641/113853414-87d90480-9795-11eb-92f8-e6198c53442e.png">
