### PR TITLE
Text style tweaks

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 const markdownIt = require("markdown-it");
 const markdownItAnchor = require("markdown-it-anchor");
+const markdownLinks = require("markdown-it-link-attributes");
 const slugify = require("@sindresorhus/slugify");
 const { paired, single } = require("./src/_includes/shortcodes");
 
@@ -26,6 +27,17 @@ module.exports = (config) => {
     permalink: true, // show link to headings
     permalinkSymbol, // nice svg link icon
     permalinkAttrs: (slug) => ({ "aria-label": `link to ${slug} section` }),
+  });
+
+  md.use(markdownLinks, {
+    matcher(href) {
+      // match any links starting with http or https
+      return href.match(/^https?:/);
+    },
+    attrs: {
+      target: "_blank",
+      rel: "noopener",
+    },
   });
 
   config.setLibrary("md", md);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@11ty/eleventy": "^1.0.0",
         "@sindresorhus/slugify": "^1.1.0",
         "markdown-it": "^12.3.2",
-        "markdown-it-anchor": "^7.1.0"
+        "markdown-it-anchor": "^7.1.0",
+        "markdown-it-link-attributes": "^4.0.0"
       },
       "devDependencies": {
         "eslint": "^7.19.0"
@@ -2460,6 +2461,11 @@
       "peerDependencies": {
         "markdown-it": "*"
       }
+    },
+    "node_modules/markdown-it-link-attributes": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-link-attributes/-/markdown-it-link-attributes-4.0.0.tgz",
+      "integrity": "sha512-ssjxSLlLfQBkX6BvAx1rCPrx7ZoK91llQQvS3P7KXvlbnVD34OUkfXwWecN7su/7mrI/HOW0RI5szdJOIqYC3w=="
     },
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
@@ -6094,6 +6100,11 @@
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-7.1.0.tgz",
       "integrity": "sha512-loQggrwsIkkP7TOrESvmYkV2ikbQNNKhHcWyqC7/C2CmfHl1tkUizJJU8C5aGgg7J6oXVQJx17gk7i47tNn/lQ==",
       "requires": {}
+    },
+    "markdown-it-link-attributes": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-link-attributes/-/markdown-it-link-attributes-4.0.0.tgz",
+      "integrity": "sha512-ssjxSLlLfQBkX6BvAx1rCPrx7ZoK91llQQvS3P7KXvlbnVD34OUkfXwWecN7su/7mrI/HOW0RI5szdJOIqYC3w=="
     },
     "maximatch": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@11ty/eleventy": "^1.0.0",
     "@sindresorhus/slugify": "^1.1.0",
     "markdown-it": "^12.3.2",
-    "markdown-it-anchor": "^7.1.0"
+    "markdown-it-anchor": "^7.1.0",
+    "markdown-it-link-attributes": "^4.0.0"
   },
   "devDependencies": {
     "eslint": "^7.19.0"

--- a/src/_data/config.json
+++ b/src/_data/config.json
@@ -47,7 +47,7 @@
     },
     "fonts": {
       "body": "Spectral",
-      "heading": "Lato"
+      "heading": "Inter"
     }
   }
 }

--- a/src/_includes/base.11ty.js
+++ b/src/_includes/base.11ty.js
@@ -48,7 +48,10 @@ exports.render = (data) => {
               date,
               seconds: readingTime && getReadingTime(content),
             })}
-        <main class="layout ${flow && "py-gutter--md flow"} ${measure}">
+        <main
+          class="layout ${flow && "py-gutter--md flow"} ${measure}"
+          style="--flow-space: 1.5rem"
+        >
           ${blocks ? blocks.map(renderBlock(data)) : content}
         </main>
         <footer>

--- a/src/_includes/base.11ty.js
+++ b/src/_includes/base.11ty.js
@@ -107,7 +107,7 @@ function Socials({ socials, className, size = 24 }) {
       ${Object.entries(socials).map(
         ([name, { url, icon }]) => html`
           <li>
-            <a href=${url}>
+            <a href=${url} target="_blank" rel="noopener">
               <img src=${icon} alt="${name}" width="${size}" height="${size}" />
             </a>
           </li>

--- a/src/css/partials/global.css
+++ b/src/css/partials/global.css
@@ -33,8 +33,7 @@ h6 {
   line-height: 1.2;
 }
 
-h2,
-h3 {
+h2 {
   text-decoration-style: solid;
   text-decoration-line: underline;
   text-decoration-color: var(--alternate);

--- a/src/css/partials/global.css
+++ b/src/css/partials/global.css
@@ -39,7 +39,6 @@ h2 {
   text-decoration-color: var(--alternate);
   text-decoration-thickness: 0.5rem;
   text-decoration-skip-ink: none;
-  text-decoration-skip: none;
   text-underline-offset: -0.6rem;
 }
 


### PR DESCRIPTION
Fixes a bunch of issues around text styling.

- [x] Open all external links in new tab [#62]
- [x] Change heading font to Inter [#73]
- [x] Remove underline from h3 elements [#65]
- [x] Increase space between body elements [#64]
- [x] Stop heading underlines rendering on Safari (I could not find a way to make it go behind the text—fuck Safari)

Check the preview deploy to see the changes live