### PR TITLE
Remove starting indentation from HTML shortcodes

### DIFF
--- a/src/_includes/shortcodes.js
+++ b/src/_includes/shortcodes.js
@@ -10,37 +10,33 @@ function layout(content, size) {
 }
 
 function image(src, caption, alt = "") {
-  return html`
-    <details data-lightbox>
-      <summary>
-        <figure class="vstack">
-          <img src="${src}" alt="${alt}" />
-          <figcaption class="text-align:center fz-sm color-text-light">
-            ${caption}
-          </figcaption>
-        </figure>
-      </summary>
-      <img src="${src}" />
-    </details>
-  `;
+  return html`<details data-lightbox>
+    <summary>
+      <figure class="vstack">
+        <img src="${src}" alt="${alt}" />
+        <figcaption class="text-align:center fz-sm color-text-light">
+          ${caption}
+        </figcaption>
+      </figure>
+    </summary>
+    <img src="${src}" />
+  </details>`;
 }
 
 function youtube(id) {
-  return html`
-    <lite-youtube
-      videoid="${id}"
-      params="modestbranding=2"
-      style="background-image: url('https://i.ytimg.com/vi/${id}/hqdefault.jpg');"
-    >
-      <noscript>
-        <a
-          href="https://youtube.com/watch?v=${id}"
-          class="lty-playbtn"
-          title="Play Video"
-        ></a>
-      </noscript>
-    </lite-youtube>
-  `;
+  return html`<lite-youtube
+    videoid="${id}"
+    params="modestbranding=2"
+    style="background-image: url('https://i.ytimg.com/vi/${id}/hqdefault.jpg');"
+  >
+    <noscript>
+      <a
+        href="https://youtube.com/watch?v=${id}"
+        class="lty-playbtn"
+        title="Play Video"
+      ></a>
+    </noscript>
+  </lite-youtube>`;
 }
 
 module.exports = { paired: { callout, layout }, single: { image, youtube } };

--- a/src/_includes/work.11ty.js
+++ b/src/_includes/work.11ty.js
@@ -16,7 +16,6 @@ exports.render = ({ info, content }) => {
         )}
       </dl>
     `;
-    console.log({ box });
     return box + content;
   }
   return content;


### PR DESCRIPTION
Their return value including whitespace is preserved when they are rendered in markdown. Markdown treats whitespace as significant, so this is bad.