### PR TITLE
Stop image popups cutting off

### DIFF
--- a/src/css/partials/components.css
+++ b/src/css/partials/components.css
@@ -177,14 +177,17 @@ animated-carousel li {
   z-index: 10;
 }
 
+[data-lightbox] summary ~ img {
+  width: auto;
+}
+
 [data-lightbox][open] summary ~ img {
-  --margin: 8rem;
   position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  max-width: calc(100% - var(--margin));
-  max-height: calc(100% - var(--margin));
+  max-width: calc(100% - var(--gutter));
+  max-height: calc(100% - var(--gutter));
   box-shadow: 0 2px 2px hsla(0, 0%, 0%, 10%), 0 6px 12px hsla(0, 0%, 0%, 25%);
   object-fit: cover;
 }


### PR DESCRIPTION
Don't stretch image popups to full width.

Instead let just render at their intrinsic file size.

Also reduce margin slightly to match other elements.

Fix #85

<img width="1624" alt="Screenshot 2022-11-17 at 15 35 11" src="https://user-images.githubusercontent.com/9408641/202489572-bc17c3b9-a689-4f27-b444-01a51feb272d.png">
<img width="1624" alt="Screenshot 2022-11-17 at 15 35 15" src="https://user-images.githubusercontent.com/9408641/202489590-7f3b06d7-4c7d-4145-b853-36666011106a.png">
<img width="562" alt="Screenshot 2022-11-17 at 15 35 19" src="https://user-images.githubusercontent.com/9408641/202489605-6682b54a-7f24-4105-9d32-fa9192364bc3.png">
